### PR TITLE
Added Workload Identity and contributor network access to cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ docker run --rm -v $(pwd):/src -w /src -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -
 
 | Name                                                          | Version |
 |---------------------------------------------------------------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi)       | ~> 1.2  |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.24 |
 | <a name="provider_http"></a> [http](#provider\_http)          | ~> 3.2  |
 
@@ -87,7 +86,6 @@ No modules.
 
 | Name                                                                                                                                                                                | Type        |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [azapi_resource.flux_addon](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource)                                                                     | resource    |
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster)                                               | resource    |
 | [azurerm_network_security_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group)                                       | resource    |
 | [azurerm_role_assignment.aks_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)                                  | resource    |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Simple public AKS cluster with automatic authorized IP address configuration for demos.
 
+## Important considerations and pre-requisites
+1. This cluster enables the public preview for workload identity, which involves enabling extensions and OIDC issuer endpoints.
+2. This cluster will install the flux addon even if it's not used or configured (it's just easier for demos)
+3. **IMPORTANT** In order to use this with any Azure subscription, you need to enable workload identity preview. Follow the steps [here](https://learn.microsoft.com/en-us/azure/aks/workload-identity-deploy-cluster#register-the-enableworkloadidentitypreview-feature-flag) to do that. The TL;DR is to run the following commands:
+```sh
+az feature register --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
+# Run the following command until you see that the feature is "Registered" (will take a few minutes)
+az feature show --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
+# Once the feature is registered, run this command to refresh the provider registration
+az provider register --namespace Microsoft.ContainerService
+```
+
 ## Running pre-commit checks
 Run the following command with docker installed and running:
 ```sh
@@ -55,6 +67,7 @@ docker run --rm -v $(pwd):/src -w /src -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -
 | Name                                                                      | Version |
 |---------------------------------------------------------------------------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3  |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi)             | ~> 1.2  |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | ~> 3.24 |
 | <a name="requirement_http"></a> [http](#requirement\_http)                | ~> 3.2  |
 
@@ -62,6 +75,7 @@ docker run --rm -v $(pwd):/src -w /src -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -
 
 | Name                                                          | Version |
 |---------------------------------------------------------------|---------|
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi)       | ~> 1.2  |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.24 |
 | <a name="provider_http"></a> [http](#provider\_http)          | ~> 3.2  |
 
@@ -73,8 +87,10 @@ No modules.
 
 | Name                                                                                                                                                                                | Type        |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| [azapi_resource.flux_addon](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource)                                                                     | resource    |
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster)                                               | resource    |
 | [azurerm_network_security_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group)                                       | resource    |
+| [azurerm_role_assignment.aks_network_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment)                                  | resource    |
 | [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                                                                       | resource    |
 | [azurerm_subnet_network_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_network_security_group_association) | resource    |
 | [azurerm_user_assigned_identity.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity)                                        | resource    |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ docker run --rm -v $(pwd):/src -w /src -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -
 | Name                                                                      | Version |
 |---------------------------------------------------------------------------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3  |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi)             | ~> 1.2  |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | ~> 3.24 |
 | <a name="requirement_http"></a> [http](#requirement\_http)                | ~> 3.2  |
 

--- a/main.tf
+++ b/main.tf
@@ -14,9 +14,9 @@ resource "azurerm_user_assigned_identity" "aks" {
 }
 
 resource "azurerm_role_assignment" "aks_network_contributor" {
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
   scope                = azurerm_virtual_network.main.id
   role_definition_name = "Network Contributor"
-  principal_id         = azurerm_user_assigned_identity.aks.principal_id
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
@@ -26,10 +26,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   # Allow the current client's public IP address only
   api_server_authorized_ip_ranges = ["${chomp(data.http.myip.response_body)}/32"]
   dns_prefix                      = var.cluster_dns_prefix
+  oidc_issuer_enabled             = true
   private_cluster_enabled         = false
   sku_tier                        = var.cluster_sku_tier
   tags                            = var.tags
-  oidc_issuer_enabled             = true
   workload_identity_enabled       = true
 
   default_node_pool {

--- a/main.tf
+++ b/main.tf
@@ -1,49 +1,10 @@
-# INFRASTRUCTURE STARTS HERE
-
 data "azurerm_resource_group" "main" {
   name = var.resource_group_name
 }
 
-resource "azurerm_virtual_network" "main" {
-  address_space       = [var.vnet_cidr]
-  location            = data.azurerm_resource_group.main.location
-  name                = var.vnet_name
-  resource_group_name = data.azurerm_resource_group.main.name
-  tags                = var.tags
+data "http" "myip" {
+  url = "https://ipv4.icanhazip.com"
 }
-
-resource "azurerm_subnet" "main" {
-  address_prefixes     = [var.subnet_cidr]
-  name                 = var.subnet_name
-  resource_group_name  = azurerm_virtual_network.main.resource_group_name
-  virtual_network_name = azurerm_virtual_network.main.name
-}
-
-resource "azurerm_network_security_group" "main" {
-  location            = data.azurerm_resource_group.main.location
-  name                = "nsg-${azurerm_subnet.main.name}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  tags                = var.tags
-
-  security_rule {
-    access                     = "Allow"
-    direction                  = "Inbound"
-    name                       = "AllowCidrBlockHTTPInbound"
-    priority                   = 3000
-    protocol                   = "Tcp"
-    destination_address_prefix = "*"
-    destination_port_ranges    = ["80", "443"]
-    source_address_prefix      = "${chomp(data.http.myip.response_body)}/32"
-    source_port_range          = "*"
-  }
-}
-
-resource "azurerm_subnet_network_security_group_association" "main" {
-  network_security_group_id = azurerm_network_security_group.main.id
-  subnet_id                 = azurerm_subnet.main.id
-}
-
-## CLUSTER RESOURCES
 
 resource "azurerm_user_assigned_identity" "aks" {
   location            = data.azurerm_resource_group.main.location
@@ -52,20 +13,24 @@ resource "azurerm_user_assigned_identity" "aks" {
   tags                = var.tags
 }
 
-data "http" "myip" {
-  url = "https://ipv4.icanhazip.com"
+resource "azurerm_role_assignment" "aks_network_contributor" {
+  scope                = azurerm_virtual_network.main.id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.aks.principal_id
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  location                        = data.azurerm_resource_group.main.location
-  name                            = var.cluster_name
-  resource_group_name             = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
+  name                = var.cluster_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  # Allow the current client's public IP address only
   api_server_authorized_ip_ranges = ["${chomp(data.http.myip.response_body)}/32"]
   dns_prefix                      = var.cluster_dns_prefix
   private_cluster_enabled         = false
-  # Allow the current client's public IP address only
-  sku_tier = var.cluster_sku_tier
-  tags     = var.tags
+  sku_tier                        = var.cluster_sku_tier
+  tags                            = var.tags
+  oidc_issuer_enabled             = true
+  workload_identity_enabled       = true
 
   default_node_pool {
     name           = "default"

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,38 @@
+resource "azurerm_virtual_network" "main" {
+  address_space       = [var.vnet_cidr]
+  location            = data.azurerm_resource_group.main.location
+  name                = var.vnet_name
+  resource_group_name = data.azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "main" {
+  address_prefixes     = [var.subnet_cidr]
+  name                 = var.subnet_name
+  resource_group_name  = azurerm_virtual_network.main.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+}
+
+resource "azurerm_network_security_group" "main" {
+  location            = data.azurerm_resource_group.main.location
+  name                = "nsg-${azurerm_subnet.main.name}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  tags                = var.tags
+
+  security_rule {
+    access                     = "Allow"
+    direction                  = "Inbound"
+    name                       = "AllowCidrBlockHTTPInbound"
+    priority                   = 3000
+    protocol                   = "Tcp"
+    destination_address_prefix = "*"
+    destination_port_ranges    = ["80", "443"]
+    source_address_prefix      = "${chomp(data.http.myip.response_body)}/32"
+    source_port_range          = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "main" {
+  network_security_group_id = azurerm_network_security_group.main.id
+  subnet_id                 = azurerm_subnet.main.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "api_server_authorized_ip_ranges" {
-  value       = azurerm_kubernetes_cluster.main.api_server_authorized_ip_ranges
+  value       = "${chomp(data.http.myip.response_body)}/32"
   description = "CIDR range of IP addresses that can access the cluster's API server's public endpoint"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,12 +51,6 @@ variable "default_node_pool_vm_size" {
   default     = "Standard_D2s_v3"
 }
 
-# variable "subnet_allow_inbound_http" {
-#   type        = bool
-#   description = "Create a security rule for the subnet to allow HTTP inbound traffic from the current TF client's IP address if true"
-#   default     = true
-# }
-
 variable "subnet_cidr" {
   type        = string
   description = "CIDR range for the cluster subnet"

--- a/versions.tf
+++ b/versions.tf
@@ -6,12 +6,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.24"
     }
-
-    azapi = {
-      source  = "azure/azapi"
-      version = "~> 1.2"
-    }
-
     http = {
       source  = "hashicorp/http"
       version = "~> 3.2"

--- a/versions.tf
+++ b/versions.tf
@@ -7,6 +7,11 @@ terraform {
       version = "~> 3.24"
     }
 
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 1.2"
+    }
+
     http = {
       source  = "hashicorp/http"
       version = "~> 3.2"


### PR DESCRIPTION
Added Workload Identity to the AKS module and gave the cluster contributor network access.

- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine